### PR TITLE
Basic pagination using will_paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'omniauth-github'
 gem 'omniauth-bitbucket'
 gem 'rest_client'
 gem 'dalli'
+gem 'will_paginate', '~> 3.0.6'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 #gem 'therubyracer', platforms: :ruby

--- a/app/assets/stylesheets/tools.css.scss
+++ b/app/assets/stylesheets/tools.css.scss
@@ -27,8 +27,10 @@ ul.tools, ul.citations {
   li {
     margin-bottom: 1em;
   }
+
   margin-left: 0;
   list-style: none;
+  clear: both;
 
   .stargazers_count {
     margin-right: 1em;
@@ -36,6 +38,10 @@ ul.tools, ul.citations {
   li {
     padding-bottom: 6px;
     border-bottom: 1px solid #eee;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
   }
 }
 
@@ -82,5 +88,40 @@ ul.reproducibility_checklist {
   li {
     margin-right: 1em;
     display: inline;
+  }
+}
+
+// Pagination control
+.pagination {
+  margin-top: 1em;
+  margin-bottom: 2em;
+
+  a, span, em {
+    padding: 0.2em 0.5em;
+    display: block;
+    float: left;
+  }
+
+  .disabled {
+    display: none;
+  }
+
+  .current {
+    font-style: normal;
+    font-weight: bold;
+    background: #29abe2;
+    color: white;
+  }
+
+  a:hover, a:focus {
+    color: darken(#29abe2, 10%);
+  }
+
+  &:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
   }
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,7 @@
 class PagesController < ApplicationController
   def home
-    @tools = Tool.order('reproducibility_score DESC').limit(100).all
+    @tools = Tool.order('reproducibility_score DESC')
+                 .page(params[:page]).per_page(25)
     @tool = Tool.new
   end
 end

--- a/app/views/pages/home.html.slim
+++ b/app/views/pages/home.html.slim
@@ -5,10 +5,12 @@
       h1.headline ScienceToolbox
 .row
   .small-12.columns
-    p.text-center We're currently forced to hard limit the number of results shown on this page. Sorry, we'll fix it soon! Search is coming too. Also, some citations are incorrect, this is very much an early alpha version, feedback welcome!
+    p.text-center Search is coming soon! Also, some citations are incorrect, this is very much an early alpha version, feedback welcome!
     br
     br
+  = will_paginate @tools, previous_label: "&laquo Previous", next_label: "Next &raquo"
   = render 'pages/tool_list', tools: @tools
+  = will_paginate @tools, previous_label: "&laquo Previous", next_label: "Next &raquo"
 .row.form
   .small-12.columns
     = render 'tools/form', tool: @tool


### PR DESCRIPTION
This adds pagination to work around hard limit of shown tools introduced in 454ef78fa01c5f5008d2c128bc1a645031f9fe42.

Currently showing 25 tools per page. Please let me know if you'd like anything implemented differently!