### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/lib/importer/paper.rb
+++ b/lib/importer/paper.rb
@@ -27,7 +27,7 @@ module Importer
     end
 
     def self.doi_url(doi)
-      "http://dx.doi.org/" + doi
+      "https://doi.org/" + doi
     end
 
     def initialize(result, text, source)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI URLs.

Cheers!